### PR TITLE
add c++11 as std to the default_options

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('VFRToCFR',
         'cpp',
-        default_options : 'buildtype=release',
+        default_options : ['buildtype=release', 'c_std=c11', 'cpp_std=c++11'],
         license : 'BSD-3-Clause',
         version : '1')
 


### PR DESCRIPTION
no more errors when building, e.g.
```
../VFRToCFR.cpp:70:20: error: expected ';' at end of declaration
        unsigned int count{ 0 };
                          ^
                          ;
../VFRToCFR.cpp:149:37: error: expected ';' at end of declaration
                        std::deque<timestamp> choicesTemp{ choices };
                                                         ^
                                                         ;
../VFRToCFR.cpp:260:39: error: expected ';' at end of declaration
        VFRToCFRData* data = new VFRToCFRData{ d };
                                             ^
                                             ;
5 errors generated.```